### PR TITLE
✨ 로그인, access 토큰 재발급 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	testImplementation("io.mockk:mockk:1.12.4")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,10 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     implementation ("com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:latest.release")
-//    implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release"))
+	implementation("io.jsonwebtoken:jjwt-api:0.11.2")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
-	testImplementation("io.mockk:mockk:1.12.4")
+	testImplementation("com.ninja-squad:springmockk:3.1.1")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/yapp/weekand/common/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/config/security/SecurityConfig.kt
@@ -1,21 +1,42 @@
 package com.yapp.weekand.common.config.security
 
+import com.yapp.weekand.common.jwt.JwtAuthenticationFilter
+import com.yapp.weekand.common.jwt.JwtProvider
 import org.springframework.beans.factory.annotation.Configurable
 import org.springframework.context.annotation.Bean
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.builders.WebSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configurable
 @EnableWebSecurity
-class SecurityConfig : WebSecurityConfigurerAdapter() {
+class SecurityConfig(
+	private val jwtProvider: JwtProvider
+) : WebSecurityConfigurerAdapter() {
+	@Bean
+	fun encoder(): PasswordEncoder = BCryptPasswordEncoder()
 
-    @Bean
-    fun encoder(): PasswordEncoder = BCryptPasswordEncoder()
+	override fun configure(web: WebSecurity) {
+		web
+			.ignoring().antMatchers("/api/v1/login", "/api/v1/signup", "/api/v1/refresh")
+	}
 
-    override fun configure(http: HttpSecurity?) {
-        http!!.csrf().disable().cors()
+    override fun configure(http: HttpSecurity) {
+		http
+			.httpBasic().disable()
+			.csrf().disable()
+			.httpBasic().disable()
+			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.and()
+			.authorizeRequests()
+			.antMatchers("/graphql").authenticated()
+			.antMatchers("/api/v1/signup", "/api/v1/login", "/api/v1/refresh").permitAll()
+			.and()
+			.addFilterBefore(JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter::class.java)
     }
 }

--- a/src/main/kotlin/com/yapp/weekand/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/error/ErrorCode.kt
@@ -11,11 +11,13 @@ enum class ErrorCode(
 ) {
 	// Common
 	REQUEST_ERROR(HttpStatus.BAD_REQUEST,2000, "입력 값을 확인해주세요."),
-	USER_NOT_FOUND(HttpStatus.NOT_FOUND,2001, "존재하지 않는 유저입니다."),
-	EXPIRED_JWT(HttpStatus.FORBIDDEN,2002, "유효기간이 만료된 JWT입니다."),
-	INVALID_JWT(HttpStatus.FORBIDDEN,2003, "유효하지 않은 JWT입니다."),
-	INVALID_REFRESH_JWT(HttpStatus.FORBIDDEN,2004, "유효하지 않은 리프레시 토큰입니다."),
-	EMPTY_JWT(HttpStatus.FORBIDDEN,2005, "JWT를 입력해주세요."),
-	INVALID_USER_JWT(HttpStatus.UNAUTHORIZED,2006,"권한이 없는 유저의 접근입니다."),
-	LOGIN_FAIL(HttpStatus.UNAUTHORIZED,2007, "이메일, 비밀번호가 일치하지 않습니다."),
+
+	//Auth
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND,3001, "존재하지 않는 유저입니다."),
+	EXPIRED_JWT(HttpStatus.FORBIDDEN,3002, "유효기간이 만료된 JWT입니다."),
+	INVALID_JWT(HttpStatus.FORBIDDEN,3003, "유효하지 않은 JWT입니다."),
+	INVALID_REFRESH_JWT(HttpStatus.FORBIDDEN,3004, "유효하지 않은 리프레시 토큰입니다."),
+	EMPTY_JWT(HttpStatus.FORBIDDEN,3005, "JWT를 입력해주세요."),
+	INVALID_USER_JWT(HttpStatus.UNAUTHORIZED,3006,"권한이 없는 유저의 접근입니다."),
+	LOGIN_FAIL(HttpStatus.UNAUTHORIZED,3007, "이메일, 비밀번호가 일치하지 않습니다."),
 }

--- a/src/main/kotlin/com/yapp/weekand/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/error/ErrorCode.kt
@@ -1,0 +1,21 @@
+package com.yapp.weekand.common.error
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import org.springframework.http.HttpStatus
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+enum class ErrorCode(
+	val status: HttpStatus,
+	val code: Int,
+	val message: String
+) {
+	// Common
+	REQUEST_ERROR(HttpStatus.BAD_REQUEST,2000, "입력 값을 확인해주세요."),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND,2001, "존재하지 않는 유저입니다."),
+	EXPIRED_JWT(HttpStatus.FORBIDDEN,2002, "유효기간이 만료된 JWT입니다."),
+	INVALID_JWT(HttpStatus.FORBIDDEN,2003, "유효하지 않은 JWT입니다."),
+	INVALID_REFRESH_JWT(HttpStatus.FORBIDDEN,2004, "유효하지 않은 리프레시 토큰입니다."),
+	EMPTY_JWT(HttpStatus.FORBIDDEN,2005, "JWT를 입력해주세요."),
+	INVALID_USER_JWT(HttpStatus.UNAUTHORIZED,2006,"권한이 없는 유저의 접근입니다."),
+	LOGIN_FAIL(HttpStatus.UNAUTHORIZED,2007, "이메일, 비밀번호가 일치하지 않습니다."),
+}

--- a/src/main/kotlin/com/yapp/weekand/common/error/ErrorResponse.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/error/ErrorResponse.kt
@@ -1,0 +1,13 @@
+package com.yapp.weekand.common.error
+
+class ErrorResponse(
+	val status: Int,
+	val code: Int,
+	val message: String
+) {
+	companion object {
+		fun error(e: ErrorCode): ErrorResponse {
+			return ErrorResponse(e.status.value(), e.code, e.message)
+		}
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/common/error/exception/BaseException.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/error/exception/BaseException.kt
@@ -1,0 +1,7 @@
+package com.yapp.weekand.common.error.exception
+
+import com.yapp.weekand.common.error.ErrorCode
+
+open class BaseException(
+	open val errorCode: ErrorCode
+): RuntimeException(errorCode.message)

--- a/src/main/kotlin/com/yapp/weekand/common/error/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/error/exception/ExceptionHandler.kt
@@ -1,0 +1,15 @@
+package com.yapp.weekand.common.error.exception
+
+import com.yapp.weekand.common.error.ErrorResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@RestControllerAdvice
+class ExceptionHandler {
+
+	@ExceptionHandler(BaseException::class)
+	fun handleBaseException(e: BaseException): ResponseEntity<ErrorResponse> {
+		return ResponseEntity.status(e.errorCode.status).body(ErrorResponse.error(e.errorCode))
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/common/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/jwt/JwtAuthenticationFilter.kt
@@ -1,0 +1,54 @@
+package com.yapp.weekand.common.jwt
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.yapp.weekand.common.error.ErrorCode
+import com.yapp.weekand.common.error.ErrorResponse
+import com.yapp.weekand.common.util.Logger
+import io.jsonwebtoken.ExpiredJwtException
+import org.springframework.http.MediaType
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.GenericFilterBean
+import javax.servlet.FilterChain
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class JwtAuthenticationFilter(
+	private val jwtProvider: JwtProvider
+): GenericFilterBean() {
+	override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+		try {
+			val accessToken: String = jwtProvider.resolveAccessToken(request as HttpServletRequest)
+			jwtProvider.parseToken(accessToken)
+			setAuthentication(accessToken)
+		}  catch (e: ExpiredJwtException) {
+			Logger.info(e.message)
+			sendErrorResponse(response as HttpServletResponse, ErrorCode.EXPIRED_JWT)
+			return
+		} catch (e: NullPointerException) {
+			Logger.info(e.message)
+			sendErrorResponse(response as HttpServletResponse, ErrorCode.EMPTY_JWT)
+			return
+		} catch (e: Exception) {
+			Logger.info(e.message)
+			sendErrorResponse(response as HttpServletResponse, ErrorCode.INVALID_JWT)
+			return
+		}
+		chain.doFilter(request, response)
+	}
+
+	private fun setAuthentication(accessToken: String) {
+		val authentication = jwtProvider.getAuthentication(accessToken)
+		SecurityContextHolder.getContext().authentication = authentication
+	}
+
+	private fun sendErrorResponse(response: HttpServletResponse, errorCode: ErrorCode) {
+		val errorResponse = ErrorResponse.error(errorCode)
+		val mapper = jacksonObjectMapper()
+		response.characterEncoding = "UTF-8"
+		response.status = errorCode.status.value()
+		response.contentType = MediaType.APPLICATION_JSON_VALUE
+		response.writer.write(mapper.writeValueAsString(errorResponse))
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/common/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/jwt/JwtProvider.kt
@@ -1,0 +1,82 @@
+package com.yapp.weekand.common.jwt
+
+import com.yapp.weekand.common.jwt.user.UserDetailServiceImpl
+import com.yapp.weekand.common.jwt.user.UserDetailsImpl
+import io.jsonwebtoken.*
+import io.jsonwebtoken.security.Keys
+import org.springframework.security.core.Authentication
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.nio.charset.StandardCharsets
+import java.security.Key
+import java.util.*
+import javax.servlet.http.HttpServletRequest
+
+@Component
+@Transactional(readOnly = true)
+class JwtProvider(
+	private val userDetailsService: UserDetailServiceImpl,
+	@Value("\${jwt.secret}") private val secretKey: String,
+	@Value("\${jwt.access-token-expiry}") private val accessTokenValidTime: Int,
+	@Value("\${jwt.refresh-token-expiry}") private val refreshTokenValidTime: Int,
+	@Value("\${jwt.access-token-header}") private val ACCESS_TOKEN_HEADER: String,
+	@Value("\${jwt.refresh-token-header}") private val REFRESH_TOKEN_HEADER: String
+)
+{
+	private val key:Key = Keys.hmacShaKeyFor(secretKey.toByteArray(StandardCharsets.UTF_8))
+
+	fun createAccessToken(email: String): String{
+		val claims: Claims = Jwts.claims().setSubject(email)
+		val now = Date()
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(now)
+			.setExpiration(Date(now.time + accessTokenValidTime))
+			.signWith(SignatureAlgorithm.HS256, key)
+			.compact()
+	}
+
+	fun createRefreshToken(): String{
+		val now = Date()
+		return Jwts.builder()
+			.setIssuedAt(now)
+			.setExpiration(Date(now.time + refreshTokenValidTime))
+			.signWith(SignatureAlgorithm.HS256, key)
+			.compact()
+	}
+
+	fun getAuthentication(token: String): Authentication {
+		val userDetails = userDetailsService.loadUserByUsername(getUserPk(token))
+		return UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+	}
+
+	fun getFromSecurityContextHolder(): UserDetailsImpl {
+		return SecurityContextHolder.getContext().authentication.principal as UserDetailsImpl
+	}
+
+	fun getUserPk(token: String): String {
+		return try {
+			parseToken(token).body.subject
+		} catch (e: ExpiredJwtException) {
+			e.claims.subject
+		}
+	}
+
+	fun resolveAccessToken(request: HttpServletRequest): String {
+		return request.getHeader(ACCESS_TOKEN_HEADER)
+	}
+
+	fun resolveRefreshToken(request: HttpServletRequest): String {
+		return request.getHeader(REFRESH_TOKEN_HEADER)
+	}
+
+	fun parseToken(token: String): Jws<Claims> {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/common/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/jwt/JwtProvider.kt
@@ -21,7 +21,7 @@ class JwtProvider(
 	private val userDetailsService: UserDetailServiceImpl,
 	@Value("\${jwt.secret}") private val secretKey: String,
 	@Value("\${jwt.access-token-expiry}") private val accessTokenValidTime: Int,
-	@Value("\${jwt.refresh-token-expiry}") private val refreshTokenValidTime: Int,
+	@Value("\${jwt.refresh-token-expiry}") private val refreshTokenValidTime: Long,
 	@Value("\${jwt.access-token-header}") private val ACCESS_TOKEN_HEADER: String,
 	@Value("\${jwt.refresh-token-header}") private val REFRESH_TOKEN_HEADER: String
 )

--- a/src/main/kotlin/com/yapp/weekand/common/jwt/user/UserDetailServiceImpl.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/jwt/user/UserDetailServiceImpl.kt
@@ -1,0 +1,16 @@
+package com.yapp.weekand.common.jwt.user
+
+import com.yapp.weekand.domain.auth.exception.UserNotFoundException
+import com.yapp.weekand.domain.user.repository.UserRepository
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Service
+
+@Service
+class UserDetailServiceImpl(
+	private val userRepository: UserRepository
+): UserDetailsService {
+	override fun loadUserByUsername(username: String): UserDetails {
+		return UserDetailsImpl(userRepository.findByEmail(username) ?: throw UserNotFoundException())
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/common/jwt/user/UserDetailsImpl.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/jwt/user/UserDetailsImpl.kt
@@ -1,0 +1,37 @@
+package com.yapp.weekand.common.jwt.user
+
+import com.yapp.weekand.domain.user.entity.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+class UserDetailsImpl(
+	val user: User
+) : UserDetails {
+	override fun getAuthorities(): MutableCollection<out GrantedAuthority>? {
+		return null
+	}
+
+	override fun getPassword(): String? {
+		return null
+	}
+
+	override fun getUsername(): String {
+		return user.email
+	}
+
+	override fun isAccountNonExpired(): Boolean {
+		return true
+	}
+
+	override fun isAccountNonLocked(): Boolean {
+		return true
+	}
+
+	override fun isCredentialsNonExpired(): Boolean {
+		return true
+	}
+
+	override fun isEnabled(): Boolean {
+		return true
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/common/util/Logger.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/util/Logger.kt
@@ -1,0 +1,21 @@
+package com.yapp.weekand.common.util
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class Logger {
+	companion object {
+		private val log : Logger get() = LoggerFactory.getLogger(this::class.java)
+		fun error(message: String?) {
+			log.error(message)
+		}
+
+		fun info(message: String?) {
+			log.info(message)
+		}
+
+		fun trace(message: String?) {
+			log.trace(message)
+		}
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/auth/controller/AuthController.kt
@@ -1,0 +1,32 @@
+package com.yapp.weekand.domain.auth.controller
+
+import com.yapp.weekand.common.jwt.JwtProvider
+import com.yapp.weekand.domain.auth.dto.LoginRequest
+import com.yapp.weekand.domain.auth.dto.LoginResponse
+import com.yapp.weekand.domain.auth.dto.ReissueAccessTokenResponse
+import com.yapp.weekand.domain.auth.service.AuthService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@RestController
+@RequestMapping("/api/v1")
+class AuthController(
+	private val authService: AuthService,
+	private val jwtProvider: JwtProvider
+) {
+
+	@PostMapping("/login")
+	fun login(@RequestBody loginRequestInput: LoginRequest): ResponseEntity<LoginResponse> {
+		return ResponseEntity.status(HttpStatus.OK).body(authService.login(loginRequestInput))
+	}
+
+	@PostMapping("/refresh")
+	fun renewAccessToken(request: HttpServletRequest, response: HttpServletResponse): ResponseEntity<ReissueAccessTokenResponse> {
+		val refreshToken:String = jwtProvider.resolveRefreshToken(request)
+		val accessToken:String = jwtProvider.resolveAccessToken(request)
+		return ResponseEntity.status(HttpStatus.OK).body(authService.renewAccessToken(accessToken, refreshToken))
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/domain/auth/dto/LoginRequest.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/auth/dto/LoginRequest.kt
@@ -1,0 +1,6 @@
+package com.yapp.weekand.domain.auth.dto
+
+class LoginRequest (
+	val email: String,
+	val password: String
+)

--- a/src/main/kotlin/com/yapp/weekand/domain/auth/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/auth/dto/LoginResponse.kt
@@ -1,0 +1,6 @@
+package com.yapp.weekand.domain.auth.dto
+
+class LoginResponse (
+	val accessToken: String?,
+	val refreshToken: String?
+)

--- a/src/main/kotlin/com/yapp/weekand/domain/auth/dto/ReissueAccessTokenResponse.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/auth/dto/ReissueAccessTokenResponse.kt
@@ -1,0 +1,5 @@
+package com.yapp.weekand.domain.auth.dto
+
+class ReissueAccessTokenResponse (
+	val accessToken: String
+)

--- a/src/main/kotlin/com/yapp/weekand/domain/auth/exception/InvalidTokenException.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/auth/exception/InvalidTokenException.kt
@@ -1,0 +1,6 @@
+package com.yapp.weekand.domain.auth.exception
+
+import com.yapp.weekand.common.error.ErrorCode
+import com.yapp.weekand.common.error.exception.BaseException
+
+class InvalidTokenException: BaseException(ErrorCode.INVALID_REFRESH_JWT)

--- a/src/main/kotlin/com/yapp/weekand/domain/auth/exception/LoginFailException.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/auth/exception/LoginFailException.kt
@@ -1,0 +1,6 @@
+package com.yapp.weekand.domain.auth.exception
+
+import com.yapp.weekand.common.error.ErrorCode
+import com.yapp.weekand.common.error.exception.BaseException
+
+class LoginFailException: BaseException(ErrorCode.LOGIN_FAIL)

--- a/src/main/kotlin/com/yapp/weekand/domain/auth/exception/UserNotFoundException.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/auth/exception/UserNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.yapp.weekand.domain.auth.exception
+
+import com.yapp.weekand.common.error.ErrorCode
+import com.yapp.weekand.common.error.exception.BaseException
+
+class UserNotFoundException: BaseException(ErrorCode.USER_NOT_FOUND)

--- a/src/main/kotlin/com/yapp/weekand/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/auth/service/AuthService.kt
@@ -26,7 +26,7 @@ class AuthService (
 ) {
 
 	@Value("\${jwt.refresh-token-expiry}")
-	private val refreshTokenExpiry: Int = 0
+	private val refreshTokenExpiry: Long = 0
 
 	fun login(loginRequest: LoginRequest): LoginResponse {
 		val user = userRepository.findByEmail(loginRequest.email)

--- a/src/main/kotlin/com/yapp/weekand/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/auth/service/AuthService.kt
@@ -1,0 +1,63 @@
+package com.yapp.weekand.domain.auth.service
+
+import com.yapp.weekand.domain.auth.exception.UserNotFoundException
+import com.yapp.weekand.common.util.Logger
+import com.yapp.weekand.common.jwt.JwtProvider
+import com.yapp.weekand.domain.auth.dto.LoginRequest
+import com.yapp.weekand.domain.auth.dto.LoginResponse
+import com.yapp.weekand.domain.auth.dto.ReissueAccessTokenResponse
+import com.yapp.weekand.domain.user.entity.User
+import com.yapp.weekand.domain.auth.exception.InvalidTokenException
+import com.yapp.weekand.domain.auth.exception.LoginFailException
+import com.yapp.weekand.domain.user.repository.UserRepository
+import com.yapp.weekand.infra.redis.RedisService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AuthService (
+	private val userRepository: UserRepository,
+	private val jwtProvider: JwtProvider,
+	private val redisService: RedisService,
+	private val passwordEncoder: PasswordEncoder
+) {
+
+	@Value("\${jwt.refresh-token-expiry}")
+	private val refreshTokenExpiry: Int = 0
+
+	fun login(loginRequest: LoginRequest): LoginResponse {
+		val user = userRepository.findByEmail(loginRequest.email)
+			?: throw LoginFailException()
+
+		if (!passwordEncoder.matches(loginRequest.password, user.password)) {
+			throw LoginFailException()
+		}
+
+		val accessToken = jwtProvider.createAccessToken(user.email)
+		val refreshToken = jwtProvider.createRefreshToken()
+		redisService.setValue(refreshToken, user.email, refreshTokenExpiry)
+		Logger.info(refreshTokenExpiry.toString())
+
+		return LoginResponse(
+			accessToken = accessToken,
+			refreshToken = refreshToken
+		)
+	}
+
+	fun renewAccessToken(accessToken: String, refreshToken: String): ReissueAccessTokenResponse {
+		val user: User = userRepository.findByEmail(jwtProvider.getUserPk(accessToken))
+			?: throw UserNotFoundException()
+
+		val email: String = redisService.getValue(refreshToken)
+			?: throw InvalidTokenException()
+
+		if (email != user.email) {
+			throw InvalidTokenException()
+		}
+
+		return ReissueAccessTokenResponse(jwtProvider.createAccessToken(user.email))
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/user/repository/UserRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository :JpaRepository<User, Long> {
 	fun existsUserByNickname(nickname:String): Boolean
-	fun findUserByEmail(email: String): User?
+	fun findByEmail(email: String): User?
 }

--- a/src/main/kotlin/com/yapp/weekand/infra/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/yapp/weekand/infra/redis/RedisConfig.kt
@@ -1,0 +1,31 @@
+package com.yapp.weekand.infra.redis
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+@EnableRedisRepositories
+class RedisConfig (
+	@Value("\${spring.redis.host}") val redisHost: String,
+	@Value("\${spring.redis.port}") val redisPort: Int
+) {
+	@Bean
+	fun redisConnectionFactory(): RedisConnectionFactory{
+		return LettuceConnectionFactory(redisHost, redisPort);
+	}
+
+	@Bean
+	fun redisTemplate(): RedisTemplate<String, Any>{
+		val redisTemplate = RedisTemplate<String, Any>()
+		redisTemplate.setConnectionFactory(redisConnectionFactory())
+		redisTemplate.keySerializer = StringRedisSerializer()
+		redisTemplate.valueSerializer = StringRedisSerializer()
+		return redisTemplate
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/infra/redis/RedisService.kt
+++ b/src/main/kotlin/com/yapp/weekand/infra/redis/RedisService.kt
@@ -1,0 +1,24 @@
+package com.yapp.weekand.infra.redis
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import java.time.Duration
+
+@Service
+class RedisService (
+	private val redisTemplate: RedisTemplate<String, String>
+) {
+	fun setValue(token: String, email: String, time: Int) {
+		val values = redisTemplate.opsForValue()
+		values.set(token, email, Duration.ofMinutes(time.toLong()))
+	}
+
+	fun getValue(token: String): String? {
+		val values = redisTemplate.opsForValue()
+		return values.get(token)
+	}
+
+	fun deleteValue(token: String) {
+		redisTemplate.delete(token)
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/infra/redis/RedisService.kt
+++ b/src/main/kotlin/com/yapp/weekand/infra/redis/RedisService.kt
@@ -8,9 +8,9 @@ import java.time.Duration
 class RedisService (
 	private val redisTemplate: RedisTemplate<String, String>
 ) {
-	fun setValue(token: String, email: String, time: Int) {
+	fun setValue(token: String, email: String, time: Long) {
 		val values = redisTemplate.opsForValue()
-		values.set(token, email, Duration.ofMinutes(time.toLong()))
+		values.set(token, email, Duration.ofMinutes(time))
 	}
 
 	fun getValue(token: String): String? {

--- a/src/test/kotlin/com/yapp/weekand/common/config/security/SecurityConfigTest.kt
+++ b/src/test/kotlin/com/yapp/weekand/common/config/security/SecurityConfigTest.kt
@@ -1,0 +1,68 @@
+package com.yapp.weekand.common.config.security
+
+import com.yapp.weekand.common.entity.EntityFactory
+import com.yapp.weekand.common.error.ErrorCode
+import com.yapp.weekand.common.jwt.JwtProvider
+import com.yapp.weekand.domain.user.repository.UserRepository
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.transaction.annotation.Transactional
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+class SecurityConfigTest{
+
+	@Autowired
+	lateinit var userRepository: UserRepository
+
+	@Autowired
+	lateinit var jwtProvider: JwtProvider
+
+	@Autowired
+	private lateinit var mockMvc: MockMvc
+
+	@Test
+	@DisplayName("access token 으로 필터를 통과한다.")
+	fun `access token 필터 통과`() {
+
+		userRepository.save(
+			EntityFactory.testLoginUser()
+		)
+
+		val accessToken = jwtProvider.createAccessToken("test@naver.com")
+
+		mockMvc
+			.perform(post("/pass-filter").header("Access-Token", accessToken))
+			.andExpect(status().isNotFound)
+			.andDo(print())
+	}
+
+	@Test
+	@DisplayName("access token이 empty일 경우 예외를 반환한다.")
+	fun `access token empty 에러`() {
+		mockMvc
+			.perform(post("/empty-token-error"))
+			.andExpect(jsonPath("$.code").value(ErrorCode.EMPTY_JWT.code))
+			.andExpect(jsonPath("$.message").value(ErrorCode.EMPTY_JWT.message))
+			.andDo(print())
+	}
+
+	@Test
+	@DisplayName("access token이 유효하지 않다면 예외를 반환한다.")
+	fun `access token 유효기간 에러`() {
+		mockMvc
+			.perform(post("/invalid-token-error").header("Access-Token", "accesstoken"))
+			.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_JWT.code))
+			.andExpect(jsonPath("$.message").value(ErrorCode.INVALID_JWT.message))
+			.andDo(print())
+	}
+}

--- a/src/test/kotlin/com/yapp/weekand/common/entity/EntityFactory.kt
+++ b/src/test/kotlin/com/yapp/weekand/common/entity/EntityFactory.kt
@@ -1,0 +1,29 @@
+package com.yapp.weekand.common.entity
+
+import com.yapp.weekand.domain.auth.dto.LoginRequest
+import com.yapp.weekand.domain.auth.dto.LoginResponse
+import com.yapp.weekand.domain.user.entity.User
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+
+class EntityFactory {
+	companion object{
+		val passwordEncoder: PasswordEncoder = BCryptPasswordEncoder()
+
+		fun testLoginUser() = User(
+			email= "test@naver.com",
+			nickname = "위캔드",
+			password = passwordEncoder.encode("weekand1234!"),
+			marketingAgreed = true)
+
+		fun loginRequest() = LoginRequest(
+			email = "test",
+			password = "weekand1234!"
+		)
+
+		fun loginResponse() = LoginResponse(
+			accessToken = "accessToken",
+			refreshToken = "refreshToken"
+		)
+	}
+}

--- a/src/test/kotlin/com/yapp/weekand/domain/auth/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/yapp/weekand/domain/auth/controller/AuthControllerTest.kt
@@ -1,0 +1,80 @@
+package com.yapp.weekand.domain.auth.controller
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.yapp.weekand.common.entity.EntityFactory
+import com.yapp.weekand.common.jwt.JwtProvider
+import com.yapp.weekand.domain.auth.dto.ReissueAccessTokenResponse
+import com.yapp.weekand.domain.auth.service.AuthService
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+
+@WebMvcTest(AuthController::class)
+@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith(MockKExtension::class)
+class AuthControllerTest {
+
+	@Autowired
+	private lateinit var mockMvc: MockMvc
+
+	@MockkBean
+	private lateinit var authService: AuthService
+
+	@MockkBean
+	lateinit var jwtProvider: JwtProvider
+
+	@Test
+	@DisplayName("로그인을 한다")
+	fun `로그인`() {
+	    //given
+		val loginRequest = EntityFactory.loginRequest()
+		val loginResponse = EntityFactory.loginResponse()
+
+		//when
+		every { authService.login(any()) } returns loginResponse
+
+		//then
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/api/v1/login")
+				.content(jacksonObjectMapper().writeValueAsString(loginRequest))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(MockMvcResultHandlers.print())
+			.andExpect(MockMvcResultMatchers.status().isOk)
+			.andExpect(jsonPath("$.accessToken").value(loginResponse.accessToken))
+			.andExpect(jsonPath("$.refreshToken").value(loginResponse.refreshToken))
+	}
+
+	@Test
+	@DisplayName("access token을 재발급 받는다.")
+	fun `access token 재발급`() {
+		//given
+		val reissueAccessTokenResponse = ReissueAccessTokenResponse("NewAccessToken")
+
+		//when
+		every { jwtProvider.resolveRefreshToken(any()) } returns "refreshToken"
+		every { jwtProvider.resolveAccessToken(any()) } returns "preAccessToken"
+		every { authService.reissueAccessToken(any(), any()) } returns reissueAccessTokenResponse
+
+		//then
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/api/v1/refresh")
+				.header("Access-Token", "preAccessToken")
+				.header("Refresh-Token", "refreshtoken"))
+			.andDo(MockMvcResultHandlers.print())
+			.andExpect(MockMvcResultMatchers.status().isOk)
+			.andExpect(jsonPath("$.accessToken").value(reissueAccessTokenResponse.accessToken))
+	}
+}

--- a/src/test/kotlin/com/yapp/weekand/domain/auth/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/yapp/weekand/domain/auth/service/AuthServiceTest.kt
@@ -1,0 +1,79 @@
+package com.yapp.weekand.domain.auth.service
+
+import com.yapp.weekand.common.entity.EntityFactory
+import com.yapp.weekand.domain.auth.dto.LoginRequest
+import com.yapp.weekand.domain.user.entity.User
+import com.yapp.weekand.domain.auth.exception.LoginFailException
+import com.yapp.weekand.common.jwt.JwtProvider
+import com.yapp.weekand.domain.user.repository.UserRepository
+import com.yapp.weekand.infra.redis.RedisService
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.anyString
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@ExtendWith(MockKExtension::class)
+class AuthServiceTest {
+
+	@InjectMockKs
+	lateinit var authService: AuthService
+
+	@MockK(relaxed = true)
+	lateinit var userRepository: UserRepository
+
+	@MockK
+	lateinit var jwtProvider: JwtProvider
+
+	@MockK(relaxed = true)
+	lateinit var redisService: RedisService
+
+	@MockK
+	private var user: User =  EntityFactory.testLoginUser()
+
+	@MockK(relaxed = true)
+	private lateinit var passwordEncoder: PasswordEncoder
+
+	@Test
+	@DisplayName("로그인을 한다.")
+	fun `로그인`() {
+		val loginRequest = LoginRequest(email = "test@naver.com", password = "weekand1234!")
+		every{ userRepository.findByEmail(anyString())} returns user
+		every{ passwordEncoder.matches(any(), any()) } returns true
+		every{ user.password } returns passwordEncoder.encode("weekand1234!")
+		every{ jwtProvider.createAccessToken(any()) } returns "accesstoken"
+		every{ jwtProvider.createRefreshToken() } returns "refreshtoken"
+
+		val resultLogin = authService.login(loginRequest)
+
+		Assertions.assertThat(resultLogin.accessToken).isNotEmpty
+	}
+
+	@Test
+	@DisplayName("이메일에 일치하는 유저가 없다면 예외를 반환한다.")
+	fun `로그인 시 유저가 존재하지 않는 예외`() {
+		every{ userRepository.findByEmail(anyString())} returns null
+
+		assertThrows<LoginFailException> {
+			authService.login(LoginRequest(email = "test@naver.com", password = "weekand1234!"))
+		}
+	}
+
+	@Test
+	@DisplayName("비밀번호가 일치하지 않다면 예외를 반환한다.")
+	fun `로그인 시 비밀번호가 일치하지 않는 예외`() {
+		every{ userRepository.findByEmail(anyString())} returns user
+
+		every{ passwordEncoder.matches(any(), any()) } returns false
+
+		assertThrows<LoginFailException> {
+			authService.login(LoginRequest(email = "test@naver.com", password = "weekand1234!"))
+		}
+	}
+}


### PR DESCRIPTION
## ☁️ 개요
- #35 

## ✏️ 작업 내용
- access, refresh 토큰 발급 (로그인) api
- refresh 토큰으로 access 토큰 재발급 api

## 🔎 추가 내용
- 한 번에 많은 수정 죄송합니다... ㅠ... 초반이라 테스트 등 세팅할게 더 있어서 이렇게 되어버렸습니다.. ㅜㅜㅜ
- refresh 토큰 저장을 redis에 하도록 해서 로컬에 redis가 있어야 실행 가능합니다
- 토큰 설정으로 인해 yml 파일을 수정하였는데, 관련 파일은 스프린트 5에 업로드 해두겠습니다!
