### PR TITLE
✨ 팔로워 목록 조회

### DIFF
--- a/src/main/kotlin/com/yapp/weekand/common/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/config/security/SecurityConfig.kt
@@ -23,7 +23,7 @@ class SecurityConfig(
 
 	override fun configure(web: WebSecurity) {
 		web
-			.ignoring().antMatchers("/api/v1/login", "/api/v1/signup", "/api/v1/refresh")
+			.ignoring().antMatchers("/api/v1/login", "/api/v1/signup", "/api/v1/refresh", "/graphiql")
 	}
 
     override fun configure(http: HttpSecurity) {

--- a/src/main/kotlin/com/yapp/weekand/common/entity/BaseEntity.kt
+++ b/src/main/kotlin/com/yapp/weekand/common/entity/BaseEntity.kt
@@ -13,9 +13,9 @@ import javax.persistence.MappedSuperclass
 abstract class BaseEntity {
     @CreatedDate
     @Column(name = "date_created", updatable = false)
-    var date_created: LocalDateTime = LocalDateTime.now()
+    var dateCreated: LocalDateTime = LocalDateTime.now()
 
     @LastModifiedDate
-    @Column(name = "date_updated")
-    var date_updated: LocalDateTime = LocalDateTime.now()
+	@Column(name = "date_updated")
+	var dateUpdated: LocalDateTime = LocalDateTime.now()
 }

--- a/src/main/kotlin/com/yapp/weekand/domain/follow/dto/FollowDto.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/follow/dto/FollowDto.kt
@@ -1,0 +1,19 @@
+package com.yapp.weekand.domain.follow.dto
+
+class FollowDto {
+	class getFollowsResponse(
+		val pageInfo: PageInfo,
+		val follows: List<Follows>
+	)
+
+	class Follows (
+		val id: Long?,
+		val nickname: String,
+		val goal: String,
+		val profileFilename: String?
+	)
+
+	class PageInfo(
+		val hasNext: Boolean
+	)
+}

--- a/src/main/kotlin/com/yapp/weekand/domain/follow/dto/FollowDto.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/follow/dto/FollowDto.kt
@@ -1,9 +1,9 @@
 package com.yapp.weekand.domain.follow.dto
 
 class FollowDto {
-	class getFollowsResponse(
+	class followerList(
 		val pageInfo: PageInfo,
-		val follows: List<Follows>
+		val followers: List<Follows>
 	)
 
 	class Follows (

--- a/src/main/kotlin/com/yapp/weekand/domain/follow/entity/Follow.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/follow/entity/Follow.kt
@@ -1,4 +1,4 @@
-package com.yapp.weekand.domain.follow2.entity
+package com.yapp.weekand.domain.follow.entity
 
 import com.yapp.weekand.domain.user.entity.User
 import com.yapp.weekand.common.entity.BaseEntity

--- a/src/main/kotlin/com/yapp/weekand/domain/follow/entity/Follow.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/follow/entity/Follow.kt
@@ -1,4 +1,4 @@
-package com.yapp.weekand.domain.follow.entity
+package com.yapp.weekand.domain.follow2.entity
 
 import com.yapp.weekand.domain.user.entity.User
 import com.yapp.weekand.common.entity.BaseEntity

--- a/src/main/kotlin/com/yapp/weekand/domain/follow/repository/FollowRepository.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/follow/repository/FollowRepository.kt
@@ -1,0 +1,11 @@
+package com.yapp.weekand.domain.follow.repository
+
+import com.yapp.weekand.domain.follow.entity.Follow
+import com.yapp.weekand.domain.user.entity.User
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FollowRepository: JpaRepository<Follow, Long> {
+	fun findByFolloweeUserOrderByDateCreated(user: User, pageable: Pageable): Slice<Follow>
+}

--- a/src/main/kotlin/com/yapp/weekand/domain/follow/resolver/FollowResolver.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/follow/resolver/FollowResolver.kt
@@ -13,8 +13,8 @@ class FollowResolver (
 	private val userService: UserService
 ) {
 	@DgsQuery
-	fun getFollowers(page:Int, size:Int): FollowDto.getFollowsResponse {
+	fun followers(page:Int, size:Int): FollowDto.followerList {
 		val followers = followService.getFollowers(userService.getCurrentUser(), PageRequest.of(page, size))
-		return FollowDto.getFollowsResponse(FollowDto.PageInfo(followers.hasNext()), follows = followers.content)
+		return FollowDto.followerList(FollowDto.PageInfo(followers.hasNext()), followers = followers.content)
 	}
 }

--- a/src/main/kotlin/com/yapp/weekand/domain/follow/resolver/FollowResolver.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/follow/resolver/FollowResolver.kt
@@ -1,0 +1,20 @@
+package com.yapp.weekand.domain.follow.resolver
+
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsQuery
+import com.yapp.weekand.domain.follow.dto.FollowDto
+import com.yapp.weekand.domain.follow.service.FollowService
+import com.yapp.weekand.domain.user.service.UserService
+import org.springframework.data.domain.PageRequest
+
+@DgsComponent
+class FollowResolver (
+	private val followService: FollowService,
+	private val userService: UserService
+) {
+	@DgsQuery
+	fun getFollowers(page:Int, size:Int): FollowDto.getFollowsResponse {
+		val followers = followService.getFollowers(userService.getCurrentUser(), PageRequest.of(page, size))
+		return FollowDto.getFollowsResponse(FollowDto.PageInfo(followers.hasNext()), follows = followers.content)
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/domain/follow/service/FollowService.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/follow/service/FollowService.kt
@@ -1,0 +1,22 @@
+package com.yapp.weekand.domain.follow.service
+
+import com.yapp.weekand.domain.follow.dto.FollowDto
+import com.yapp.weekand.domain.follow.entity.Follow
+import com.yapp.weekand.domain.follow.repository.FollowRepository
+import com.yapp.weekand.domain.user.entity.User
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class FollowService(
+	private val followRepository: FollowRepository
+) {
+	fun getFollowers(user: User, pageable: Pageable): Slice<FollowDto.Follows> {
+		return followRepository.findByFolloweeUserOrderByDateCreated(user, pageable)
+			.map(Follow::followerUser)
+			.map{ FollowDto.Follows(id = it.id, nickname = it.nickname, goal = it.goal, profileFilename = it.profileFilename) }
+	}
+}

--- a/src/main/kotlin/com/yapp/weekand/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/yapp/weekand/domain/user/service/UserService.kt
@@ -1,5 +1,6 @@
 package com.yapp.weekand.domain.user.service
 
+import com.yapp.weekand.common.jwt.JwtProvider
 import com.yapp.weekand.domain.user.repository.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -7,9 +8,12 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class UserService (
-	private val userRepository: UserRepository
+	private val userRepository: UserRepository,
+	private val jwtProvider: JwtProvider
 ){
 	fun checkDuplicateNickname(nickname: String) = userRepository.existsUserByNickname(nickname)
 
 	fun findUserById(id: Long) = userRepository.findById(id).get()
+
+	fun getCurrentUser() = jwtProvider.getFromSecurityContextHolder().user
 }

--- a/src/main/resources/schema/follow.graphqls
+++ b/src/main/resources/schema/follow.graphqls
@@ -1,0 +1,15 @@
+type GetFollowsResponse {
+	pageInfo: PageInfo
+	follows: [Follower]
+}
+
+type PageInfo {
+	hasNext: Boolean!
+}
+
+type Follower{
+	id: ID
+	nickname: String
+	profileUrl: String
+	goal: String
+}

--- a/src/main/resources/schema/follow.graphqls
+++ b/src/main/resources/schema/follow.graphqls
@@ -1,13 +1,13 @@
-type GetFollowsResponse {
+type FollowerList {
 	pageInfo: PageInfo
-	follows: [Follower]
+	followers: [FollowUser!]!
 }
 
 type PageInfo {
 	hasNext: Boolean!
 }
 
-type Follower{
+type FollowUser{
 	id: ID
 	nickname: String
 	profileUrl: String

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -6,7 +6,7 @@ type Query {
     weekand(customField: String): Weekand!
 	checkDuplicateNickname(nickname: String!): Boolean!
 	user(id: ID!): User
-	getFollowers(page: Int!, size: Int!): GetFollowsResponse!
+	followers(page: Int!, size: Int!): FollowerList!
 }
 
 type Weekand {

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -6,6 +6,7 @@ type Query {
     weekand(customField: String): Weekand!
 	checkDuplicateNickname(nickname: String!): Boolean!
 	user(id: ID!): User
+	getFollowers(page: Int!, size: Int!): GetFollowsResponse!
 }
 
 type Weekand {

--- a/src/test/kotlin/com/yapp/weekand/domain/auth/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/yapp/weekand/domain/auth/controller/AuthControllerTest.kt
@@ -66,7 +66,7 @@ class AuthControllerTest {
 		//when
 		every { jwtProvider.resolveRefreshToken(any()) } returns "refreshToken"
 		every { jwtProvider.resolveAccessToken(any()) } returns "preAccessToken"
-		every { authService.reissueAccessToken(any(), any()) } returns reissueAccessTokenResponse
+		every { authService.renewAccessToken(any(), any()) } returns reissueAccessTokenResponse
 
 		//then
 		mockMvc


### PR DESCRIPTION
## ☁️ 개요
- #17 

## ✏️ 작업 내용
- 팔로워 목록 조회

## 🔎 추가 내용

- Request 
```graphql
  query{
    getFollowers(page:1, size:5){
      pageInfo{
        hasNext
      },
      follows {
        id,
        nickname,
        profileUrl,
        goal
      }
    } 
  }
  ```
page는 0부터 시작, size는 요청 데이터

- Response 
  ```graphql
  {
    "data": {
      "getFollowers": {
        "pageInfo": {
          "hasNext": true
        },
        "follows": [
          {
            "id": "98",
            "nickname": "test2",
            "profileUrl": null,
            "goal": "gg"
          },
          {
            "id": "98",
            "nickname": "test2",
            "profileUrl": null,
            "goal": "gg"
          }, 
         #...
        ]
      }
    }
  }
  ```

hasNext가 true면 다음 페이지 있음, false면 없음으로 확인

타입이나 dto 관련해서 컨벤션을 정하면 좋을 것 같습니당..!